### PR TITLE
Default in getFacturxXmlFromPdf 2nd parameter

### DIFF
--- a/src/Facturx.php
+++ b/src/Facturx.php
@@ -52,7 +52,7 @@ class Facturx
      *
      * @return string
      */
-    public function getFacturxXmlFromPdf($pdfInvoice, $checkXsd)
+    public function getFacturxXmlFromPdf($pdfInvoice, $checkXsd = true)
     {
         $pdfBinary = null;
         $pdfFile = null;


### PR DESCRIPTION
Added a default value for param $checkXsd in the method getFacturxXmlFromPdf to be compliant with the README file