### PR TITLE
Upgrade abandoned setasign/fpdi-fpdf package to setasign/fpdi

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": ">=5.6",
-        "setasign/fpdi-fpdf": "^2.0",
+        "setasign/fpdi": "^2.0",
         "smalot/pdfparser": "^0.13.2",
         "ext-dom": "*",
         "ext-simplexml": "*",


### PR DESCRIPTION
https://github.com/Setasign/FPDI-FPDF packed was abandoned and split into 2 packaged : 
- https://github.com/Setasign/FPDI
- https://github.com/Setasign/FPDF

I can see that you used only FPDI part of the package, so I removed setasign/fpdf package and upgrade to the new one for setasign/fpdi