### PR TITLE
Allows empty EF field in spec details

### DIFF
--- a/src/Facturx.php
+++ b/src/Facturx.php
@@ -75,12 +75,14 @@ class Facturx
             }
             $facturx_found = false;
             $filespec = $pdfParsed->getObjectsByType('Filespec');
-            $facturxLength = 0;
+            $facturxLength = null;
             foreach ($filespec as $spec) {
                 $specDetails = $spec->getDetails();
                 if (static::FACTURX_FILENAME == $specDetails['F']) {
                     $facturx_found = true;
-                    $facturxLength = $specDetails['EF']['F']['Length']; // Get file size
+                    if (!empty($specDetails['EF']) && isset($specDetails['EF']['F']) && isset($specDetails['EF']['F']['Length'])) {
+                        $facturxLength = $specDetails['EF']['F']['Length']; // Get file size
+                    }
                     break;
                 }
             }


### PR DESCRIPTION
Thanks for your work on this library ! 

We used this library with some producer where the "EF" fields is not provided. This merge-request allows this library to work in this particular case.

