### PR TITLE
Factur-X XML embarkation relationship

### DIFF
--- a/src/Facturx.php
+++ b/src/Facturx.php
@@ -167,22 +167,31 @@ class Facturx
     }
 
     /**
-     * Generate Factur-X PDF from PDF invoice and Factur-X XML.
-     *
-     * @param string $pdfInvoice            File name or content of the PDF invoice
-     * @param string $facturxXml            File name or content of the XML invoice
-     * @param string $facturxProfil         possible values : autodetect, minimum, basicwl, basic, en16931
-     * @param bool   $checkXsd              check Factur-X XML against official XSD
-     * @param string $outputFilePath        Output file path for PDF Factur-X, if empty, file string will be returned
-     * @param bool   $addFacturxLogo        Add Factur-X logo on PDF first page according to Factur-X profil
-     * @param mixed  $additionalAttachments
-     *
-     * @throws \Exception
-     *
-     * @return string
-     */
-    public function generateFacturxFromFiles($pdfInvoice, $facturxXml, $facturxProfil = 'autodetect', $checkXsd = true,
-                                             $outputFilePath = '', $additionalAttachments = array(), $addFacturxLogo = false)
+    * Generate Factur-X PDF from PDF invoice and Factur-X XML.
+    *
+    * @param string $pdfInvoice            File name or content of the PDF invoice
+    * @param string $facturxXml            File name or content of the XML invoice
+    * @param string $facturxProfil         possible values : autodetect, minimum, basicwl, basic, en16931
+    * @param bool   $checkXsd              check Factur-X XML against official XSD
+    * @param string $outputFilePath        Output file path for PDF Factur-X, if empty, file string will be returned
+    * @param bool   $addFacturxLogo        Add Factur-X logo on PDF first page according to Factur-X profil
+    * @param mixed  $additionalAttachments
+    * @param string $relationship          The embarkation relationship, must be Data|Source|Alternative.
+    *
+    * @throws \Exception
+    *
+    * @return string
+    */
+    public function generateFacturxFromFiles(
+        $pdfInvoice,
+        $facturxXml,
+        $facturxProfil = 'autodetect',
+        $checkXsd = true,
+        $outputFilePath = '',
+        $additionalAttachments = array(),
+        $addFacturxLogo = false,
+        $relationship = 'Data'
+    )
     {
         $pdfInvoiceRef = null;
         if (@is_file($pdfInvoice)) {
@@ -222,7 +231,10 @@ class Facturx
                 $pdfWriter->Image(__DIR__.'/../img/'.static::FACTURX_LOGO[$this->profil], 197, 2.5, 7);
             }
         }
-        $pdfWriter->Attach($facturxXmlRef, static::FACTURX_FILENAME, 'Factur-X Invoice', 'Data', 'text#2Fxml');
+        if (!in_array($relationship, ['Data', 'Source', 'Alternative'])) {
+            throw new \Exception('$relationship argument must be one of the values "Data", "Source", "Alternative".');
+        }
+        $pdfWriter->Attach($facturxXmlRef, static::FACTURX_FILENAME, 'Factur-X Invoice', $relationship, 'text#2Fxml');
         foreach ($additionalAttachments as $attachment) {
             if (@is_file($attachment['path'])) {
                 $attachment_file_ref = $attachment['path'];

--- a/tests/index.php
+++ b/tests/index.php
@@ -62,7 +62,7 @@
                         );
                     }
                     $result = $facturx->generateFacturxFromFiles($pdf, $facturx_xml,
-                        'autodetect', true, __DIR__.'/', $attachment_files, true);
+                        'autodetect', true, __DIR__.'/', $attachment_files, true, $_POST['relationship']);
                 } catch (Exception $e) {
                     $resultBodyHtml = 'Error while generating the Factur-X :<pre>' . $e.'</pre>';
                 }
@@ -95,6 +95,14 @@
                                         <div class="form-group">
                                             <label>Choose the Factur-X XML file to link</label>
                                             <input type="file" class="form-control-file" name="xml_facturx_tolink" required>
+                                        </div>
+                                        <div class="form-group">
+                                            <label>Choose the Factur-X XML file embarkation relationship</label>
+                                            <select name="relationship" class="form-control">
+                                                <option value="Data" selected>Data</option>
+                                                <option value="Source">Source</option>
+                                                <option value="Alternative">Alternative</option>
+                                            </select>
                                         </div>
                                         <div class="form-group">
                                             <label>(Optional) Choose a file to link :</label>


### PR DESCRIPTION
## What's new in this PR : 

- Add ``$relationship`` argument to ``generateFacturxFromFiles``, this argument accept only "Data", "Source", "Alternative", throw exception instead and defaults to "Data".

## Why theses changes ?

- Allow developers to choose the relationship they need.
- The Factur-X standard says that embarkation relationship must be Data, Source or Alternative  :

![image](https://user-images.githubusercontent.com/44200782/126171049-cebfbf61-0ab4-413b-a980-1be6f6fdb730.png)
