### PR TITLE
Fix XSD validation bug

### DIFF
--- a/src/Facturx.php
+++ b/src/Facturx.php
@@ -135,14 +135,14 @@ class Facturx
             throw new \Exception('$facturxXml argument must be a file or a string');
         }
 
+        if ($facturxProfil === 'autodetect') {
+            $facturxProfil = $this->getFacturxProfil($doc);
+        }
+
         if (!array_key_exists($facturxProfil, static::FACTURX_PROFIL_TO_XSD)) {
-            $this->profil = $this->getFacturxProfil($doc);
-        } else {
-            $this->profil = $facturxProfil;
+            throw new \Exception("Wrong profil '$facturxProfil' for Factur-X invoice.");
         }
-        if (!array_key_exists($this->profil, static::FACTURX_PROFIL_TO_XSD)) {
-            throw new \Exception("Wrong profil '$this->profil' for Factur-X invoice.");
-        }
+        $this->profil = $facturxProfil;
         $xsdFilename = static::FACTURX_PROFIL_TO_XSD[$this->profil];
         $xsdFile = __DIR__.'/../xsd/factur-x/'.$xsdFilename;
         try {
@@ -204,11 +204,9 @@ class Facturx
         }
         $docFacturx = new \DOMDocument();
         $docFacturx->loadXML($xmlString);
-        if (!array_key_exists(strtolower($facturxProfil), static::FACTURX_PROFIL_TO_XSD)) {
-            $facturxProfil = $this->getFacturxProfil($docFacturx);
-        }
-        $this->profil = $facturxProfil;
+
         if (true == $checkXsd) {
+            // The profil is validated inside checkFacturxXsd
             $this->checkFacturxXsd($facturxXml, $facturxProfil);
         }
 


### PR DESCRIPTION
## What's changed

- Detect profile only if the given profile is ``"autodetect"``.

## Why ?

Avoid validation wrong profiles with a valid XML. For example :
If we have a valid XML file with the ``"basicwl"`` profil, this call will return true ``checkFacturxXsd($validXml, 'wrongprofile')``.