### PR TITLE
work well with esoteric page format

### DIFF
--- a/src/Facturx.php
+++ b/src/Facturx.php
@@ -217,7 +217,7 @@ class Facturx
         for ($i = 1; $i <= $pageCount; ++$i) {
             $tplIdx = $pdfWriter->importPage($i, '/MediaBox');
             $pdfWriter->AddPage();
-            $pdfWriter->useTemplate($tplIdx);
+            $pdfWriter->useTemplate($tplIdx, 0, 0, null, null, true);
             if (true == $addFacturxLogo && 1 == $i) { // add Factur-X logo on first page only
                 $pdfWriter->Image(__DIR__.'/../img/'.static::FACTURX_LOGO[$this->profil], 197, 2.5, 7);
             }

--- a/src/Fpdi/FdpiFacturx.php
+++ b/src/Fpdi/FdpiFacturx.php
@@ -161,17 +161,19 @@ class FdpiFacturx extends \setasign\Fpdi\Fpdi
             $this->_put('/Subtype /'.$file_info['subtype']);
         }
         $this->_put('/Type /EmbeddedFile');
-        if (@is_file($file_info['file'])) {
+        if (is_string($file_info['file']) && @is_file($file_info['file'])) {
             $fc = file_get_contents($file_info['file']);
+            $md = @date('YmdHis', filemtime($file_info['file']));
         } else {
             $stream = $file_info['file']->getStream();
             \fseek($stream, 0);
             $fc = stream_get_contents($stream);
+            $md = @date('YmdHis');
         }
         if (false === $fc) {
             $this->Error('Cannot open file: '.$file_info['file']);
         }
-        $md = @date('YmdHis', filemtime($file_info['file']));
+
         $fc = gzcompress($fc);
         $this->_put('/Length '.strlen($fc));
         $this->_put("/Params <</ModDate (D:$md)>>");


### PR DESCRIPTION
If the original PDF has pages in landscape format or with esoteric page size, the ouput PDF was cropped at A4 page size.
This fix allow to keep the original page size, whatever it is. 