### PR TITLE
Add missing Size property in the embedded file

### DIFF
--- a/src/Fpdi/FdpiFacturx.php
+++ b/src/Fpdi/FdpiFacturx.php
@@ -174,10 +174,10 @@ class FdpiFacturx extends \setasign\Fpdi\Fpdi
         if (false === $fc) {
             $this->Error('Cannot open file: '.$file_info['file']);
         }
-
+        $size = strlen($fc);
         $fc = gzcompress($fc);
         $this->_put('/Length '.strlen($fc));
-        $this->_put("/Params <</ModDate (D:$md)>>");
+        $this->_put("/Params <</ModDate (D:$md) /Size $size >>");
         $this->_put('>>');
         $this->_putstream($fc);
         $this->_put('endobj');


### PR DESCRIPTION
In Adobe Acrobat Reader, 
The displayed size of facture-x attachment is 0 byte. The current changes will fix it.