### PR TITLE
Add possibilty to use poppler-utils to extract XML from PDF

### DIFF
--- a/src/Exceptions/UnableToExtractXMLException.php
+++ b/src/Exceptions/UnableToExtractXMLException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Atgp\FacturX\Exceptions;
+
+use Exception;
+
+class UnableToExtractXMLException extends Exception
+{
+}

--- a/src/Exceptions/UnableToExtractXMLException.php
+++ b/src/Exceptions/UnableToExtractXMLException.php
@@ -2,8 +2,6 @@
 
 namespace Atgp\FacturX\Exceptions;
 
-use Exception;
-
-class UnableToExtractXMLException extends Exception
+class UnableToExtractXMLException extends \Exception
 {
 }

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -10,10 +10,9 @@
 namespace Atgp\FacturX;
 
 use Atgp\FacturX\Exceptions\UnableToExtractXMLException;
-use Atgp\FacturX\XMLExtractors\XMLExtractor;
 use Atgp\FacturX\XMLExtractors\PdfParserExtractor;
+use Atgp\FacturX\XMLExtractors\XMLExtractor;
 use Exception;
-use InvalidArgumentException;
 
 class Reader
 {
@@ -31,15 +30,14 @@ class Reader
     /**
      * Extracts Factur-X XML from Factur-X PDF.
      *
-     * @param string         $pdfContentOrPath  content or path of the PDF invoice
-     * @param bool           $validateXsd       validates Factur-X XML against official XSD and throws exception if validation failed
-     * @param ?array<string> $searchFilenames   XML filenames to look for, by default searchs zugferd and factur-x filenames, must be a valid factur-x XML filename
-     *
-     * @return string the extracted XML
+     * @param string         $pdfContentOrPath content or path of the PDF invoice
+     * @param bool           $validateXsd      validates Factur-X XML against official XSD and throws exception if validation failed
+     * @param ?array<string> $searchFilenames  XML filenames to look for, by default searchs zugferd and factur-x filenames, must be a valid factur-x XML filename
      *
      * @throws UnableToExtractXMLException
-     * @throws Exception
-     * @throws InvalidArgumentException
+     * @throws \Exception
+     * @throws \InvalidArgumentException
+     * @return string                      the extracted XML
      */
     public function extractXML(
         string $pdfContentOrPath,
@@ -50,14 +48,14 @@ class Reader
         $xmlExtractor = $this->getXMLExtractor();
 
         if (!$xmlExtractor->isPdf($pdfContentOrPath)) {
-            throw new InvalidArgumentException('The $pdfContentOrPath must be content or path of a PDF file.');
+            throw new \InvalidArgumentException('The $pdfContentOrPath must be content or path of a PDF file.');
         }
 
         try {
             $xml = $this->getXMLExtractor()
                 ->extract($pdfContentOrPath, $searchFilenames ?? self::ALLOWED_FILENAMES);
-        } catch (Exception $e) {
-            throw new UnableToExtractXMLException('Unable to get Factur-x XML from PDF : ' . $e->getMessage());
+        } catch (\Exception $e) {
+            throw new UnableToExtractXMLException('Unable to get Factur-x XML from PDF : '.$e->getMessage());
         }
 
         if ($validateXsd) {
@@ -69,12 +67,12 @@ class Reader
     }
 
     /**
-     * @throws InvalidArgumentException
+     * @throws \InvalidArgumentException
      */
     private function checkXMLFilenamesAreValid(?array $searchFilenames = null): void
     {
         if ($searchFilenames && count(array_diff($searchFilenames, self::ALLOWED_FILENAMES))) {
-            throw new InvalidArgumentException('Invalid parameter $searchFilenames, only valid factur-x XML filenames are allowed :' . implode(', ', self::ALLOWED_FILENAMES));
+            throw new \InvalidArgumentException('Invalid parameter $searchFilenames, only valid factur-x XML filenames are allowed :'.implode(', ', self::ALLOWED_FILENAMES));
         }
     }
 

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -56,7 +56,7 @@ class Writer
      * @throws \Exception
      * @return string
      */
-    public function generate(string $pdfInvoice, string $xml, string $profile = null, bool $validateXSD = true,
+    public function generate(string $pdfInvoice, string $xml, ?string $profile = null, bool $validateXSD = true,
         array $additionalAttachments = [], bool $addLogo = false, string $relationship = 'Data'
     ): string {
         $pdfInvoiceRef = \setasign\Fpdi\PdfParser\StreamReader::createByString($pdfInvoice);

--- a/src/XMLExtractors/PdfDetachExtractor.php
+++ b/src/XMLExtractors/PdfDetachExtractor.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Atgp\FacturX\XMLExtractors;
+
+use Atgp\FacturX\Exceptions\UnableToExtractXMLException;
+use Atgp\FacturX\XMLExtractors\XMLExtractor;
+use Exception;
+
+class PdfDetachExtractor extends XMLExtractor
+{
+    /**
+     * @inheritDoc
+     */
+    public function extract(string $pdfPathOrContent, array $searchFilenames): string
+    {
+        try {
+            if (!@is_file($pdfPathOrContent)) {
+                $tempFile = tempnam(sys_get_temp_dir(), time());
+                @file_put_contents($tempFile, $pdfPathOrContent);
+                $pdfPathOrContent = $tempFile;
+            }
+
+            $xmlAttachmentIndex = self::getXMLAttachmentIndex($pdfPathOrContent, $searchFilenames);
+
+            $xml =  self::getAttachmentContent(
+                $pdfPathOrContent,
+                $xmlAttachmentIndex,
+            );
+
+            if (isset($tempFile)) {
+                @unlink($tempFile);
+            }
+
+            return $xml;
+        } catch (Exception $e) {
+            throw new UnableToExtractXMLException($e->getMessage());
+        }
+    }
+
+    /**
+     * @throws UnableToExtractXMLException
+     */
+    private static function getXMLAttachmentIndex(string $pdfPath, array $searchFilenames): int
+    {
+        $pdfPath = escapeshellarg($pdfPath);
+
+        exec("pdfdetach -list {$pdfPath}", $output, $resultCode);
+
+        if ($resultCode !== 0) {
+            throw new UnableToExtractXMLException((string) $output);
+        }
+
+        /**
+         * Example output :
+         * 1 embedded files
+         * 1: factur-x.xml
+         */
+        foreach ($output as $outputLine) {
+            foreach ($searchFilenames as $searchFilename) {
+                if (strpos($outputLine, $searchFilename)) {
+                    return (int) $outputLine[0];
+                }
+            }
+        }
+
+        throw new UnableToExtractXMLException('No factur-x XML attachment found');
+    }
+
+    private static function getAttachmentContent(
+        string $pdfPath,
+        int $attachmentIndex
+    ): string {
+        $pdfPath = escapeshellarg($pdfPath);
+        $attachmentIndex = escapeshellarg($attachmentIndex);
+        $xmlOutputPath = tempnam(sys_get_temp_dir(), time());
+        $escapedXmlOutputPath = escapeshellarg($xmlOutputPath);
+
+        exec(
+            "pdfdetach -save {$attachmentIndex} {$pdfPath} -o {$escapedXmlOutputPath}",
+            $output,
+            $resultCode
+        );
+
+        if ($resultCode !== 0) {
+            throw new UnableToExtractXMLException((string) $output);
+        }
+
+        $xml = @file_get_contents($xmlOutputPath);
+
+        @unlink($xmlOutputPath);
+
+        return $xml;
+    }
+}

--- a/src/XMLExtractors/PdfDetachExtractor.php
+++ b/src/XMLExtractors/PdfDetachExtractor.php
@@ -3,13 +3,11 @@
 namespace Atgp\FacturX\XMLExtractors;
 
 use Atgp\FacturX\Exceptions\UnableToExtractXMLException;
-use Atgp\FacturX\XMLExtractors\XMLExtractor;
-use Exception;
 
 class PdfDetachExtractor extends XMLExtractor
 {
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public function extract(string $pdfPathOrContent, array $searchFilenames): string
     {
@@ -22,7 +20,7 @@ class PdfDetachExtractor extends XMLExtractor
 
             $xmlAttachmentIndex = self::getXMLAttachmentIndex($pdfPathOrContent, $searchFilenames);
 
-            $xml =  self::getAttachmentContent(
+            $xml = self::getAttachmentContent(
                 $pdfPathOrContent,
                 $xmlAttachmentIndex,
             );
@@ -32,7 +30,7 @@ class PdfDetachExtractor extends XMLExtractor
             }
 
             return $xml;
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             throw new UnableToExtractXMLException($e->getMessage());
         }
     }
@@ -46,11 +44,11 @@ class PdfDetachExtractor extends XMLExtractor
 
         exec("pdfdetach -list {$pdfPath}", $output, $resultCode);
 
-        if ($resultCode !== 0) {
+        if (0 !== $resultCode) {
             throw new UnableToExtractXMLException((string) $output);
         }
 
-        /**
+        /*
          * Example output :
          * 1 embedded files
          * 1: factur-x.xml
@@ -81,7 +79,7 @@ class PdfDetachExtractor extends XMLExtractor
             $resultCode
         );
 
-        if ($resultCode !== 0) {
+        if (0 !== $resultCode) {
             throw new UnableToExtractXMLException((string) $output);
         }
 

--- a/src/XMLExtractors/PdfParserExtractor.php
+++ b/src/XMLExtractors/PdfParserExtractor.php
@@ -3,8 +3,6 @@
 namespace Atgp\FacturX\XMLExtractors;
 
 use Atgp\FacturX\Exceptions\UnableToExtractXMLException;
-use Atgp\FacturX\XMLExtractors\XMLExtractor;
-use Exception;
 use Smalot\PdfParser\Parser;
 
 class PdfParserExtractor extends XMLExtractor
@@ -19,7 +17,7 @@ class PdfParserExtractor extends XMLExtractor
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public function extract(string $pdfPathOrContent, array $searchFilenames): string
     {
@@ -57,7 +55,7 @@ class PdfParserExtractor extends XMLExtractor
             if (!$xml) {
                 throw new UnableToExtractXMLException('Factur-x Filespec not found.');
             }
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             throw new UnableToExtractXMLException($e->getMessage());
         }
 

--- a/src/XMLExtractors/PdfParserExtractor.php
+++ b/src/XMLExtractors/PdfParserExtractor.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Atgp\FacturX\XMLExtractors;
+
+use Atgp\FacturX\Exceptions\UnableToExtractXMLException;
+use Atgp\FacturX\XMLExtractors\XMLExtractor;
+use Exception;
+use Smalot\PdfParser\Parser;
+
+class PdfParserExtractor extends XMLExtractor
+{
+    private array $smalotPdfParserCfg = [];
+    private ?\Smalot\PdfParser\Config $smalotPdfParserConfig = null;
+
+    public function __construct(array $smalotPdfParserCfg = [], ?\Smalot\PdfParser\Config $smalotPdfParserConfig = null)
+    {
+        $this->smalotPdfParserCfg = $smalotPdfParserCfg;
+        $this->smalotPdfParserConfig = $smalotPdfParserConfig;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function extract(string $pdfPathOrContent, array $searchFilenames): string
+    {
+        try {
+            $parser = new Parser($this->smalotPdfParserCfg, $this->smalotPdfParserConfig);
+            $pdfParsed = @is_file($pdfPathOrContent) ?
+                $parser->parseFile($pdfPathOrContent) :
+                $parser->parseContent($pdfPathOrContent);
+
+            /** @var PDFObject $spec */
+            $xml = null;
+            foreach ($pdfParsed->getObjectsByType('Filespec') as $spec) {
+                if (!in_array($spec->get('F')->getContent(), $searchFilenames)) {
+                    continue;
+                }
+                // Not an embedded file
+                if (!$spec->has('EF')) {
+                    continue;
+                }
+
+                $embeddedFileReference = $spec->get('EF');
+                if (!$embeddedFileReference->has('F')) {
+                    // /EF /F contains reference to /EmbeddedFile object
+                    // (raw reference is not displayable with Smalot)
+                    continue;
+                }
+
+                // Smalot resolve embedded stream content directly (without need to search /EmbeddedFile by reference)
+                $xml = $embeddedFileReference->get('F')->getContent();
+                if (null === $xml) {
+                    throw new UnableToExtractXMLException('EmbeddedFile not readable.');
+                }
+            }
+
+            if (!$xml) {
+                throw new UnableToExtractXMLException('Factur-x Filespec not found.');
+            }
+        } catch (Exception $e) {
+            throw new UnableToExtractXMLException($e->getMessage());
+        }
+
+        return $xml;
+    }
+}

--- a/src/XMLExtractors/XMLExtractor.php
+++ b/src/XMLExtractors/XMLExtractor.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Atgp\FacturX\XMLExtractors;
 
 use Atgp\FacturX\Exceptions\UnableToExtractXMLException;
@@ -13,7 +12,7 @@ abstract class XMLExtractor
     abstract public function extract(string $pdfPathOrContent, array $searchFilenames): string;
 
     /**
-     * Check if the given parameter is a PDF file or PDF string
+     * Check if the given parameter is a PDF file or PDF string.
      */
     public function isPdf(string $pdfPathOrContent): bool
     {
@@ -33,6 +32,6 @@ abstract class XMLExtractor
             @unlink($filePath);
         }
 
-        return $mimeType === 'application/pdf';
+        return 'application/pdf' === $mimeType;
     }
 }

--- a/src/XMLExtractors/XMLExtractor.php
+++ b/src/XMLExtractors/XMLExtractor.php
@@ -1,0 +1,38 @@
+<?php
+
+
+namespace Atgp\FacturX\XMLExtractors;
+
+use Atgp\FacturX\Exceptions\UnableToExtractXMLException;
+
+abstract class XMLExtractor
+{
+    /**
+     * @throws UnableToExtractXMLException
+     */
+    abstract public function extract(string $pdfPathOrContent, array $searchFilenames): string;
+
+    /**
+     * Check if the given parameter is a PDF file or PDF string
+     */
+    public function isPdf(string $pdfPathOrContent): bool
+    {
+        $isInputFile = @is_file($pdfPathOrContent);
+        // if given input is not a path, create temp file to check mime type
+        $filePath = $isInputFile ? $pdfPathOrContent : tempnam(sys_get_temp_dir(), time());
+
+        // put content in temp file
+        if (!$isInputFile) {
+            @file_put_contents($filePath, $pdfPathOrContent);
+        }
+
+        $mimeType = mime_content_type($filePath);
+
+        // unlink temp file
+        if (!$isInputFile) {
+            @unlink($filePath);
+        }
+
+        return $mimeType === 'application/pdf';
+    }
+}

--- a/src/XsdValidator.php
+++ b/src/XsdValidator.php
@@ -37,7 +37,7 @@ class XsdValidator
      *
      * @return bool
      */
-    public function validate(string $xml, string $profile = null): bool
+    public function validate(string $xml, ?string $profile = null): bool
     {
         $this->errors = [];
         $this->profile = $profile;
@@ -50,6 +50,7 @@ class XsdValidator
         }
         if (!ProfileHandler::has($this->profile)) {
             $this->errors[] = "Unexpected profile '$profile' for Factur-X invoice.";
+
             return false;
         }
 
@@ -69,8 +70,9 @@ class XsdValidator
 
             return true;
         } catch (\Exception $e) {
-            $this->errors[] = 'The ' . strtoupper($this->profile) .
-                ' XML file is not valid against the official XML Schema Definition : ' . $e->getMessage();
+            $this->errors[] = 'The '.strtoupper($this->profile).
+                ' XML file is not valid against the official XML Schema Definition : '.$e->getMessage();
+
             return false;
         }
     }
@@ -80,10 +82,10 @@ class XsdValidator
      *
      * @throws \Exception
      */
-    public function validateWithException(string $xml, string $profile = null)
+    public function validateWithException(string $xml, ?string $profile = null)
     {
         if (!$this->validate($xml, $profile)) {
-            throw new \Exception(strtoupper($this->profile) . ' XML file invalid schema : ' . implode(\PHP_EOL, $this->errors));
+            throw new \Exception(strtoupper($this->profile).' XML file invalid schema : '.implode(\PHP_EOL, $this->errors));
         }
     }
 
@@ -108,7 +110,7 @@ class XsdValidator
     protected static function getXsd(string $profile): string
     {
         if (!array_key_exists($profile, static::XSD_FILENAMES)) {
-            throw new \Exception('No available XSD for profile ' . $profile);
+            throw new \Exception('No available XSD for profile '.$profile);
         }
 
         return sprintf('%s/../xsd/%s', __DIR__, static::XSD_FILENAMES[$profile]);

--- a/tests/index.php
+++ b/tests/index.php
@@ -6,7 +6,7 @@ $resultBodyHtml = '';
 
 if (isset($_FILES['pdf_facturx_extract']) && !empty($_FILES['pdf_facturx_extract'])) {
     $resultHeaderHtml = 'Extract Factur-X XML from PDF result';
-    $reader = new \Atgp\FacturX\Reader();
+    $reader = new Atgp\FacturX\Reader();
     $resultBodyHtml .= "<h4 class='text-primary'>File ".$_FILES['pdf_facturx_extract']['name'].' : </h4>';
     try {
         $content = file_get_contents($_FILES['pdf_facturx_extract']['tmp_name']);
@@ -23,7 +23,7 @@ if (isset($_FILES['pdf_facturx_extract']) && !empty($_FILES['pdf_facturx_extract
 }
 
 if (isset($_FILES['xml_facturx_check']) && !empty($_FILES['xml_facturx_check'])) {
-    $validator = new \Atgp\FacturX\XsdValidator();
+    $validator = new Atgp\FacturX\XsdValidator();
     $resultHeaderHtml = 'Check XML Factur-X result';
     $resultBodyHtml = "<h4 class='text-primary'>File ".$_FILES['xml_facturx_check']['name'].' : </h4>';
     $content = file_get_contents($_FILES['xml_facturx_check']['tmp_name']);
@@ -41,7 +41,7 @@ if (isset($_FILES['xml_facturx_check']) && !empty($_FILES['xml_facturx_check']))
 }
 
 if (isset($_FILES['pdf_classic']) && !empty($_FILES['pdf_classic'])) {
-    $writer = new \Atgp\FacturX\Writer();
+    $writer = new Atgp\FacturX\Writer();
     $resultHeaderHtml = 'Generate PDF Factur-X from PDF and Factur-X XML result';
     try {
         $pdf = file_get_contents($_FILES['pdf_classic']['tmp_name']);


### PR DESCRIPTION
### Context

Allow XML extraction using the command tool `pdfdetach` instead of `smalot\pdfparser`.

### Main changes
Ability to extract XML using `pdfdetach` : 
```php
$reader = new Atgp\FacturX\Reader(new PdfDetachExtractor());
$reader->extractXML($pdf);
```
No need to precise the extractor as param, `smalot\pdfparser` remains the default extractor so the changes are transparent for current users.

Users can also implement their own XML extractor since there are many methods to extract an XML from a PDF file.
```php
class CustomExtractor extends XMLExtractor
{
    private string $param1;
    private string $param2;

    public function __construct(string $param1, string $param2, ...)
    {
        $this->param1 = $param1;
        $this->param2 = $param2;
    }

    /**
     * {@inheritDoc}
     */
    public function extract(string $pdfPathOrContent, array $searchFilenames): string
    {
        // extract XML and return it
        // throw UnableToExtractXMLException if unable to extract any XML file from $searchFilenames
    }
}

// You may than pass your extract to the Reader class
$myCustomExtractor = new CustomExtractor('param1');
$reader = new \Atgp\FacturX\Reader($myCustomExtractor);
$facturxXml = $reader->extractXML($facturxPdf);
```
### Other changes
- Use typed exception `UnableToExtractXMLException` when unable to extract XML from PDF.
- Allow to pass either a PDF path or a PDF content the the `extractXML` method.
- Verify that the given input is PDF file by checking mime type.
- Verify that the given XML filenames are valid : only `factur-x.xml` and `zugferd-invoice.xml`, this will help prevent errors from typos and prevent looking for invalid XML file, this PHP code will throw `InvalidArgumentException`: 
```php
$reader = new Reader();
$reader->extractXML(
    $pdf, 
    true, 
    [
          'fatcur-x.xml', // notice the typo in the filename
          'not-factur-x-xml-filename.xml',
    ]
); 
```
- The method `XsdValidator::validate` should not throw exception and simply return false since we have the method `XsdValidator::validateWithException`.
- Replaced the property `xsdErrors` by a local variable since its only used internaly and was never documented. 

### Why theses changes ?

At evoliz we have been using this package for 3 years now, we are still using the v1 and we want to upgrade to v2 to get the latest XSD validation files.
We had many problems with the package `smalot\pdfparser` (memory exhausted error, pdf corrupted, infinite loops ...etc) and we want to be able to use another method of extraction (pdfdetach) in our case.

### Are there any breaking changes ?
Yes, people who used to set `$smalotPdfParserCfg` and/or `$smalotPdfParserConfig` on the class `Reader` must now upgrade because the properties have been moved the extractor class `PdfParserExtractor`

Old code example : 
```php
$reader = new Reader();
$reader->smalotPdfParserCfg = [];
$reader->smalotPdfParserConfig = $config;
$reader->extractXML();
```
New code : 
```php
$pdfParserExtractor = new PdfParserExtractor([], $config);
$reader = new Reader($pdfParserExtractor);
$reader->extractXML();
```

Thanks,
Abderraouf MAHDI.