### PR TITLE
Fix PHP 8.4 Deprecations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+    - pull_request
+    - push
+
+permissions:
+    contents: read # to fetch code (actions/checkout)
+
+jobs:
+    test:
+        strategy:
+            max-parallel: 1
+            matrix:
+                php:
+                    - '7.4'
+                    - '8.0'
+                    - '8.1'
+                    - '8.2'
+                    - '8.3'
+                    - '8.4'
+
+        runs-on: ubuntu-24.04
+
+        steps:
+            -   name: Setup PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: ${{ matrix.php }}
+                    extensions: zip
+
+            -   uses: actions/checkout@v4
+
+            -   name: Cache Composer packages
+                id: cache-composer
+                uses: actions/cache@v4
+                with:
+                    path: vendor
+                    key: ${{ runner.os }}-php${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}
+                    restore-keys: |
+                        ${{ runner.os }}-php${{ matrix.php }}-
+
+            -   name: Install dependencies
+                run: composer install --no-ansi --no-interaction --no-progress --prefer-dist
+
+            -   name: Check all PHP files Syntax
+                run: find src -type f -name "*.php" -exec php -l {} \; || exit 1
+
+            -   name: PHPStan
+                run: vendor/bin/phpstan analyse -vv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
     test:
         strategy:
-            max-parallel: 1
+            max-parallel: 3
             matrix:
                 php:
                     - '7.4'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,15 +31,6 @@ jobs:
 
             -   uses: actions/checkout@v4
 
-            -   name: Cache Composer packages
-                id: cache-composer
-                uses: actions/cache@v4
-                with:
-                    path: vendor
-                    key: ${{ runner.os }}-php${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}
-                    restore-keys: |
-                        ${{ runner.os }}-php${{ matrix.php }}-
-
             -   name: Install dependencies
                 run: composer install --no-ansi --no-interaction --no-progress --prefer-dist
 

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,10 @@
         "ext-fileinfo": "*"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "~3.1"
+        "friendsofphp/php-cs-fixer": "~3.1",
+        "phpstan/phpstan": "^2.0"
+    },
+    "scripts": {
+        "phpstan": "vendor/bin/phpstan analyse"
     }
 }

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,0 +1,12 @@
+includes:
+    - phar://phpstan.phar/conf/bleedingEdge.neon
+
+parameters:
+    level: 1
+    treatPhpDocTypesAsCertain: false
+
+    paths:
+        - src
+
+    bootstrapFiles:
+        - vendor/autoload.php

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -56,7 +56,7 @@ class Writer
      * @throws \Exception
      * @return string
      */
-    public function generate(string $pdfInvoice, string $xml, string $profile = null, bool $validateXSD = true,
+    public function generate(string $pdfInvoice, string $xml, ?string $profile = null, bool $validateXSD = true,
         array $additionalAttachments = [], bool $addLogo = false, string $relationship = 'Data'
     ): string {
         $pdfInvoiceRef = \setasign\Fpdi\PdfParser\StreamReader::createByString($pdfInvoice);

--- a/src/XsdValidator.php
+++ b/src/XsdValidator.php
@@ -44,7 +44,7 @@ class XsdValidator
      *
      * @return bool
      */
-    public function validate(string $xml, string $profile = null): bool
+    public function validate(string $xml, ?string $profile = null): bool
     {
         $this->xmlErrors = $this->errors = [];
         $this->profile = $profile;
@@ -85,7 +85,7 @@ class XsdValidator
      *
      * @throws \Exception
      */
-    public function validateWithException(string $xml, string $profile = null)
+    public function validateWithException(string $xml, ?string $profile = null): void
     {
         if (!$this->validate($xml, $profile)) {
             throw new \Exception(strtoupper($this->profile).' XML file invalid schema : '.implode(\PHP_EOL, $this->errors));


### PR DESCRIPTION
The project is generating deprecation warnings with PHP 8.4. Its about implicit nullable parameters.
See here: https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated

The fix also includes a Gitlab CI workflow for testing all supported PHP-Versions.
