### PR TITLE
Add .gitattributes to exclude files from composer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+/.github export-ignore
+/.gitignore export-ignore
+/.gitattributes export-ignore
+/.php-cs-fixer.dist.php export-ignore
+/CONTRIBUTING.md export-ignore
+/phpstan.dist.neon export-ignore
+/phpunit.xml.dist export-ignore
+/tests export-ignore
+/img export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -6,4 +6,3 @@
 /phpstan.dist.neon export-ignore
 /phpunit.xml.dist export-ignore
 /tests export-ignore
-/img export-ignore


### PR DESCRIPTION
In order to avoid having useless files installed on each server that does a composer install this change is required.

Or like here: https://github.com/hello-lemon/lemonfacturx/tree/main/vendor/atgp/factur-x